### PR TITLE
crossing out Youtube in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ sodalite is an open-source, no-fuss downloader with real-time stats and a clean 
 ## 🌐 supported services
 
 - **tiktok** → videos and audio extraction
-- **youtube** → videos, shorts, and music
+- ~~**youtube** → videos, shorts, and music~~
 - **instagram reels** → full quality downloads
 - ... more coming soon! 🚀
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ sodalite is an open-source, no-fuss downloader with real-time stats and a clean 
 ## 🌐 supported services
 
 - **tiktok** → videos and audio extraction
-- ~~**youtube** → videos, shorts, and music~~
+- ~~**youtube** → videos, shorts, and music~~ Youtube is unsupported by Sodalight for the time being
 - **instagram reels** → full quality downloads
 - ... more coming soon! 🚀
 

--- a/frontend/components/service-badges.tsx
+++ b/frontend/components/service-badges.tsx
@@ -2,7 +2,7 @@ import { Badge } from "@/components/ui/badge";
 import { Youtube, Music2, Instagram } from "lucide-react";
 
 const services = [
-  { name: "YouTube", icon: Youtube, color: "text-red-500" },
+  /*{ name: "YouTube", icon: Youtube, color: "text-red-500" },*/
   { name: "TikTok", icon: Music2, color: "text-foreground" },
   { name: "Instagram", icon: Instagram, color: "text-pink-500" },
 ];


### PR DESCRIPTION
 I crossed out Youtube in the README.md, as it isn't supported by Sodalight anymore